### PR TITLE
updating dependencies to update to laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^6.2 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",
         "squizlabs/php_codesniffer": "~2.6",
-        "friendsofphp/php-cs-fixer": "~1.12"
+        "friendsofphp/php-cs-fixer": "~1.12 || ^2.0"
     },
     "autoload": {
         "psr-4": { "Softonic\\DeveloperApiSdk\\" : "src/" }


### PR DESCRIPTION
guzzle should be updated
php-cs-fixer in order to use php 8.0 or above